### PR TITLE
bugfix and minor improvements

### DIFF
--- a/R/installModule.R
+++ b/R/installModule.R
@@ -6,7 +6,7 @@ createLocalRecord <- function(modulePkg, moduleInfo, cacheAble = TRUE, addJaspTo
     RemoteType = "local",
     RemoteUrl  = modulePkg,
     Cacheable  = cacheAble,
-    Hash       = hash
+    Hash       = unname(hash) # unname to remove the name attribute, otherwise the json becomes Hash: {<name> : <hash>} instead of Hash: <hash>
   ))
   names(record) <- moduleInfo[["Package"]]
   record

--- a/R/renvOverrides.R
+++ b/R/renvOverrides.R
@@ -88,8 +88,14 @@ renv_remotes_resolve_path_impl_override <- function(path) {
     # cat(sprintf("renv_remotes_resolve_path_impl_override, path = %s\n", path))
     Cacheable <- TRUE
     Version <- addLocalJaspToVersion(desc$Version)
-    cat(sprintf("computing hash for jasp module at path %s\n", path))
-    Hash    <- computeModuleHash(path)
+    moduleObject <- loadModuleStatusObject(returnObject = TRUE, warnIfNotExists = FALSE)
+    if (is.null(moduleObject)) {
+      cat(sprintf("computing hash for jasp module at path %s\n", path))
+      Hash    <- computeModuleHash(path)
+    } else {
+      cat(sprintf("loading cached hash for jasp module at path %s\n", path))
+      Hash    <- moduleObject[["md5sums"]][basename(path)]
+    }
 
   } else {
     Cacheable <- FALSE


### PR DESCRIPTION
- bugfix where cmake always had to be rerun
- unname the hash so the json becomes {..., Hash: <hash_value>} instead of {..., Hash: {<module_name> : <hash_value> }}. @RensDofferhoff I assume this is not an issue?
- actually use cached hashes

@shun2wang This PR should fix the issue you mentioned in https://github.com/jasp-stats/jasp-desktop/pull/5679#issuecomment-2378367493

@boutinb it should no longer be necessary to rerun cmake before every build.